### PR TITLE
fix issues with build on ios and macos

### DIFF
--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -288,6 +288,9 @@ func getModuleVersions(targetOS string, targetArch string, src string) (*modfile
 
 // writeGoMod writes go.mod file at $WORK/src when Go modules are used.
 func writeGoMod(targetOS string, targetArch string) error {
+	if targetArch == "macos64" || targetArch == "uikitMac64" {
+		targetArch = "amd64"
+	}
 	m, err := areGoModulesUsed()
 	if err != nil {
 		return err

--- a/cmd/gomobile/build.go
+++ b/cmd/gomobile/build.go
@@ -372,7 +372,7 @@ func parseBuildTarget(buildTarget string) (os string, archs []string, _ error) {
 	targetOS := os
 	if os == "ios" {
 		targetOS = "darwin"
-		return targetOS, []string{"arm", "arm64", "386", "amd64"}, nil
+		return targetOS, []string{"arm64", "amd64"}, nil
 	}
 	if os == "android" {
 		return targetOS, []string{"arm", "arm64", "386", "amd64"}, nil

--- a/cmd/gomobile/env.go
+++ b/cmd/gomobile/env.go
@@ -29,7 +29,7 @@ var (
 func allArchs(targetOS string) []string {
 	switch targetOS {
 	case "ios":
-		return []string{"arm", "arm64", "386", "amd64"}
+		return []string{"arm64", "amd64"}
 	case "android":
 		return []string{"arm", "arm64", "386", "amd64"}
 	case "macos":
@@ -146,7 +146,10 @@ func envInit() (err error) {
 
 	darwinArmNM = "nm"
 	darwinEnv = make(map[string][]string)
-	for _, arch := range allArchs("ios") {
+	darwinArchs := allArchs("ios")
+	darwinArchs = append(darwinArchs, allArchs("macos")...)
+	darwinArchs = append(darwinArchs, allArchs("macos-ui")...)
+	for _, arch := range darwinArchs {
 		var env []string
 		var err error
 		var clang, cflags string
@@ -155,13 +158,6 @@ func envInit() (err error) {
 
 		fmt.Println(arch)
 		switch arch {
-		case "arm":
-			clang, cflags, err = envClang("iphoneos")
-			cflags += " -miphoneos-version-min=" + buildIOSVersion
-		case "386":
-			clang, cflags, err = envClang("macosx")
-			cflags += " -mmacosx-version-min=10.10"
-			archNew = "386"
 		case "arm64":
 			clang, cflags, err = envClang("iphoneos")
 			cflags += " -miphoneos-version-min=" + buildIOSVersion


### PR DESCRIPTION
This does a few things:
- Remove 32 bit architectures (for darwin os) that are no longer supported in golang 1.15
- Fix a bug in envInit to include a custom environment for macos and macos-ui.
- Fix a bug in writeGoMod to have the correct architecture (amd64) instead of custom ones (macos64 and uikitMac64)